### PR TITLE
Query limiter

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlet/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlet/DataServlet.java
@@ -25,7 +25,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet that returns fake Comments. */
+/** Servlet that returns fake comments. */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 

--- a/portfolio/src/main/java/com/google/sps/servlet/DisplayCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlet/DisplayCommentsServlet.java
@@ -17,6 +17,7 @@ package com.google.sps.servlets;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
@@ -50,7 +51,7 @@ public class DisplayCommentsServlet extends HttpServlet{
         PreparedQuery results = datastore.prepare(query);
 
         List<Comment> comments= new ArrayList<>();
-        for(Entity entity: results.asIterable()){
+        for(Entity entity: results.asList(FetchOptions.Builder.withLimit(numComments))){
             long id = entity.getKey().getId();
             String userID= (String) entity.getProperty("fName");
             Date submitTime= (Date) entity.getProperty("submitTime");
@@ -63,11 +64,7 @@ public class DisplayCommentsServlet extends HttpServlet{
         Gson gson = new Gson();
 
         response.setContentType("application/json;");
-        if(comments.size() <= numComments){
-            response.getWriter().println(gson.toJson(comments));
-        }else{
-            response.getWriter().println(gson.toJson(comments.subList(0,numComments)));    
-        }
+        response.getWriter().println(gson.toJson(comments));
     }
 
     /* Changes comment display amount to destinted valaue */

--- a/portfolio/src/main/java/com/google/sps/servlet/DisplayCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlet/DisplayCommentsServlet.java
@@ -42,7 +42,7 @@ public class DisplayCommentsServlet extends HttpServlet{
         numComments= 5;
     }
 
-    /* Limits the maximum of return comments returned in single batch */
+    /* Limits the maximum # of comments returned in single batch */
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
         Query query= new Query("Comment").addSort("submitTime", SortDirection.DESCENDING);

--- a/portfolio/src/main/java/com/google/sps/servlet/DisplayCommentsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlet/DisplayCommentsServlet.java
@@ -42,7 +42,7 @@ public class DisplayCommentsServlet extends HttpServlet{
         numComments= 5;
     }
 
-    /* Queries comments before return comments are limited */
+    /* Limits the maximum of return comments returned in single batch */
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException{
         Query query= new Query("Comment").addSort("submitTime", SortDirection.DESCENDING);
@@ -67,7 +67,7 @@ public class DisplayCommentsServlet extends HttpServlet{
         response.getWriter().println(gson.toJson(comments));
     }
 
-    /* Changes comment display amount to destinted valaue */
+    /* Changes query cap to user determined value */
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException{
         numComments= Integer.parseInt(request.getParameter("numComments"));


### PR DESCRIPTION
Limit the maximum # of comments returned in single batch instead of returning a sub-list of comments.